### PR TITLE
Add missing user link

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ By default these services are exposed outside the cluster:
 
 ## :wave: Acknowledgements
 
-Huge thanks to @lrstanley for letting me use his repository documentation
+Huge thanks to [@lrstanley](https://github.com/lrstanley) for letting me use his repository documentation
 templates!
 
 ## :balance_scale: License


### PR DESCRIPTION
<!--
  🙏 Thanks for submitting a pull request to kubernetes-example! Please make sure to read our
  Contributing Guidelines, and Code of Conduct.

  ❌ You can remove any sections of this template that are not applicable to your PR.
-->

## 🚀 Changes proposed by this PR

I noticed GitHub doesn't render @mentions links in markdown files. This change explicitely adds the link in the file.

### 🧰 Type of change

- Bug fix
- This change is a documentation update

### 🤝 Requirements

- [x] ✍ I have read and agree to this projects [Code of Conduct](../../blob/main/.github/CODE_OF_CONDUCT.md).
- [x] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/main/.github/CONTRIBUTING.md).
- [x] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] 🔎 I have performed a self-review of my own changes.
- [x] 🎨 My changes follow the style guidelines of this project.
